### PR TITLE
Altered the way the rebuild script handled kernels and checksums.

### DIFF
--- a/src/actions/rebuild.py
+++ b/src/actions/rebuild.py
@@ -8,9 +8,10 @@ import lib.message as message
 import actions.common as common
 
 def detect_boot():
-    global initrd, vmlinuz
+    global initrd, vmlinuz, xenkernel
     initrd = None
     vmlinuz = None
+    xenkernel = None
 
     for sfile in sorted(misc.list_files(misc.join_paths(config.FILESYSTEM_DIR, 'boot'))):
         if 'initrd.img' in sfile:
@@ -19,11 +20,15 @@ def detect_boot():
         elif 'vmlinuz' in sfile:
             vmlinuz = sfile
             message.sub_debug('Vmlinuz detected', sfile)
-
+        elif 'xen' in sfile:
+            if 'gz' in sfile:
+                xenkernel = sfile
+                message.sub_debug('Xen kernel detected', sfile)
 
 def main():
     common.check_filesystem()
 
+    # Basic sanity checks of files and paths that absolutely need to exist.
     message.sub_info('Doing sanity checks')
     lsb_file = misc.join_paths(config.FILESYSTEM_DIR, 'etc/lsb-release')
     if not os.path.isfile(lsb_file):
@@ -52,6 +57,7 @@ def main():
         message.sub_debug('Removing', base_file)
         os.unlink(base_file)
 
+    # Acquire distribution information from the FileSystem
     message.sub_info('Gathering information')
     arch = misc.chroot_exec(('dpkg', '--print-architecture'), prepare=False, \
         mount=False, output=True)
@@ -63,6 +69,7 @@ def main():
     message.sub_debug('Distribution (DISTRIB_ID)', distrib)
     message.sub_debug('Release (DISTRIB_RELEASE)', release)
 
+    # Remove files, by name, that we know we must repopulate if they exist.
     message.sub_info('Cleaning up')
     cleanup_files = ['casper/filesystem.squashfs', 'casper/initrd.lz', \
         'casper/vmlinuz', 'casper/vmlinuz.efi', 'casper/filesystem.manifest', \
@@ -74,11 +81,25 @@ def main():
             message.sub_debug('Removing', full_file)
             os.unlink(full_file)
 
+    # Define the checksum files, and the ISO filename.
+    md5sum_iso_file = misc.join_paths(config.WORK_DIR, 'md5sum')
+    sha1sum_iso_file = misc.join_paths(config.WORK_DIR, 'sha1sum')
+    sha256sum_iso_file = misc.join_paths(config.WORK_DIR, 'sha256sum')
     iso_file = '%s/%s-%s-%s.iso' % (config.WORK_DIR, distrib, arch, release)
     if os.path.exists(iso_file):
         message.sub_debug('Removing', iso_file)
         os.unlink(iso_file)
+    if os.path.exists(md5sum_iso_file):
+        message.sub_debug('Removing', md5sum_iso_file)
+        os.unlink(md5sum_iso_file)
+    if os.path.exists(sha1sum_iso_file):
+        message.sub_debug('Removing', sha1sum_iso_file)
+        os.unlink(sha1sum_iso_file)
+    if os.path.exists(sha256sum_iso_file):
+        message.sub_debug('Removing', sha256sum_iso_file)
+        os.unlink(sha256sum_iso_file)
 
+    # Detect files needed for booting, the kernel, initramfs, xen and anything else.
     detect_boot()
     if not vmlinuz:
         message.sub_info('Re-installing kernel')
@@ -98,7 +119,7 @@ def main():
         message.sub_debug('Initrd', initrd)
         message.sub_debug('Vmlinuz', vmlinuz)
         misc.copy_file(initrd, misc.join_paths(config.ISO_DIR, 'casper/initrd.lz'))
-        misc.copy_file(vmlinuz, misc.join_paths(config.ISO_DIR, 'casper/vmlinuz'))
+        
         # FIXME: extend to support grub
         efi_boot_entry = False
         isolinux_dir = config.ISO_DIR + '/isolinux'
@@ -112,6 +133,20 @@ def main():
             message.sub_debug('Copying EFI vmlinuz')
             misc.copy_file(vmlinuz, misc.join_paths(config.ISO_DIR, \
                 'casper/vmlinuz.efi'))
+            os.link(misc.join_paths(config.ISO_DIR, \
+                'casper/vmlinuz.efi'), misc.join_paths(config.ISO_DIR, \
+                'casper/vmlinuz'))
+            # EFI Kernels are still loadable by grub, modern ISOs lack a bare vmlinuz.
+            # mkisofs/genisoimage -cache-inodes reuses hard linked inodes.
+        else:
+            misc.copy_file(vmlinuz, misc.join_paths(config.ISO_DIR, 'casper/vmlinuz'))
+            # We only need to copy the bare kernel if we're not using EFI at all.
+        if xenkernel:
+            # Xen is optional, and will be included on the ISO if found.
+            message.sub_debug('Xen kernel', xenkernel)
+            misc.copy_file(xenkernel, \
+                misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(xenkernel)))
+
 
     message.sub_info('Extracting casper UUID')
     confdir = config.FILESYSTEM_DIR + '/conf'
@@ -128,11 +163,22 @@ def main():
     finally:
         shutil.rmtree(confdir)
 
-    message.sub_info('Creating squashed FileSystem')
-    misc.system_command(('mksquashfs', config.FILESYSTEM_DIR, \
+    # Define some default compression parameters, including a 1MB blocksize for all compressors.
+    compression_parameters = ('-b', '1048576', '-comp', config.COMPRESSION)
+    if config.COMPRESSION == 'xz':  # Append additional compression parameters for xz.
+        # Using the branch-call-jump filter provides a compression boost with executable code.
+        # This can save a hundred megabytes easily, on an 800MB ISO. The dictionary size must
+        # match the block size, and it's advisable to use larger block sizes, like 1MB or 4MB.
+        compression_parameters += ('-Xbcj', 'x86', '-Xdict-size', '100%')
+    message.sub_info('SquashFS Compression parameters', compression_parameters)
+
+    # Create the compressed filesystem
+    message.sub_info('Creating SquashFS Compressed Filesystem')
+    make_squash_fs = ('mksquashfs', config.FILESYSTEM_DIR, \
         misc.join_paths(config.ISO_DIR, 'casper/filesystem.squashfs'), \
-        '-wildcards', '-ef', os.path.join(sys.prefix, 'share/customizer/exclude.list'), \
-        '-comp', config.COMPRESSION))
+        '-wildcards', '-no-recovery', '-noappend', \
+        '-ef', os.path.join(sys.prefix, 'share/customizer/exclude.list'))
+    misc.system_command(make_squash_fs + compression_parameters)
 
     message.sub_info('Checking SquashFS filesystem size')
     sfs_size = os.path.getsize(misc.join_paths(config.ISO_DIR, \
@@ -165,6 +211,7 @@ def main():
     # FIXME: do some kung-fu to check if packages are installed
     # and remove them from filesystem.manifest-remove if they are not
 
+    # Creating a md5sum.txt file fixes lubuntu's integrity check.
     md5sums_file = misc.join_paths(config.ISO_DIR, 'md5sum.txt')
     if os.path.isfile(md5sums_file):
         message.sub_info('Creating md5sum.txt')
@@ -172,19 +219,54 @@ def main():
         for sfile in misc.list_files(config.ISO_DIR):
             if sfile.endswith('md5sum.txt'):
                 continue
+            if sfile.endswith('SHA256SUMS'):
+                continue
 
             # FIXME: read in chunks
-            message.sub_debug('Checksuming', sfile)
+            message.sub_debug('MD5 Checksumming', sfile)
             checksum = hashlib.md5(misc.read_file(sfile)).hexdigest()
             misc.append_file(md5sums_file, checksum + '  .' + \
                 sfile.replace(config.ISO_DIR, '') +'\n')
 
+    # Creating a SHA256SUMS file fixes ubuntu-mini-remix's integrity check.
+    shasums_file = misc.join_paths(config.ISO_DIR, 'SHA256SUMS')
+    if os.path.isfile(shasums_file):
+        message.sub_info('Creating SHA256SUMS')
+        misc.write_file(shasums_file, '')
+        for sfile in misc.list_files(config.ISO_DIR):
+            if sfile.endswith('md5sum.txt'):
+                continue
+            if sfile.endswith('SHA256SUMS'):
+                continue
+
+            # FIXME: read in chunks
+            message.sub_debug('SHA256 Checksumming', sfile)
+            checksum = hashlib.sha256(misc.read_file(sfile)).hexdigest()
+            misc.append_file(shasums_file, checksum + '  .' + \
+                sfile.replace(config.ISO_DIR, '') +'\n')
+
+
+    # Create the ISO filesystem
     message.sub_info('Creating ISO')
     os.chdir(config.ISO_DIR)
     misc.system_command(('xorriso', '-as', 'mkisofs', '-r', '-V', \
         distrib + '-' + arch + '-' + release, '-b', 'isolinux/isolinux.bin', \
         '-c', 'isolinux/boot.cat', '-J', '-l', '-no-emul-boot', \
         '-boot-load-size', '4', '-boot-info-table', '-o', iso_file, \
-        '-input-charset', 'utf-8', '.'))
+        '-cache-inodes', '-input-charset', 'utf-8', '.'))
+
+    message.sub_info('Creating ISO checksums')
+    md5checksum = hashlib.md5(misc.read_file(iso_file)).hexdigest()
+    message.sub_info('ISO md5 checksum', md5checksum)
+    misc.append_file(md5sum_iso_file, md5checksum + '  .' + \
+        iso_file.replace(config.WORK_DIR, '') +'\n')
+    sha1checksum = hashlib.sha1(misc.read_file(iso_file)).hexdigest()
+    message.sub_info('ISO sha1 checksum', sha1checksum)
+    misc.append_file(sha1sum_iso_file, sha1checksum + '  .' + \
+        iso_file.replace(config.WORK_DIR, '') +'\n')
+    sha256checksum = hashlib.sha256(misc.read_file(iso_file)).hexdigest()
+    message.sub_info('ISO sha256 checksum', sha256checksum)
+    misc.append_file(sha256sum_iso_file, sha256checksum + '  .' + \
+        iso_file.replace(config.WORK_DIR, '') +'\n')
 
     message.sub_info('Successfuly created ISO image', iso_file)

--- a/src/actions/rebuild.py
+++ b/src/actions/rebuild.py
@@ -162,26 +162,26 @@ def main():
             misc.copy_file(vmlinuz, misc.join_paths(config.ISO_DIR, 'casper/vmlinuz'))
             # We only need to copy the bare kernel if we're not using EFI at all.
 
-        # Copy optional boot-enablement packages onto the ISO, if found.
-        if mt86plus:
-            message.sub_debug('Memtest86+ kernel', mt86plus)
-            misc.copy_file(mt86plus, misc.join_paths(config.ISO_DIR, 'install/mt86plus'))
-        if xen_kernel:
-            message.sub_debug('Xen kernel', xen_kernel)
-            misc.copy_file(xen_kernel, \
-                misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(xen_kernel)))
-        if xen_efi:
-            message.sub_debug('Xen EFI kernel', xen_efi)
-            misc.copy_file(xen_efi, \
-                misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(xen_efi)))
-        if ipxe_kernel:
-            message.sub_debug('iPXE kernel', ipxe_kernel)
-            misc.copy_file(ipxe_kernel, \
-                misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(ipxe_kernel)))
-        if ipxe_efi:
-            message.sub_debug('iPXE EFI kernel', ipxe_efi)
-            misc.copy_file(ipxe_efi, \
-                misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(ipxe_efi)))
+    # Copy optional boot-enablement packages onto the ISO, if found.
+    if mt86plus:
+        message.sub_debug('Memtest86+ kernel', mt86plus)
+        misc.copy_file(mt86plus, misc.join_paths(config.ISO_DIR, 'install/mt86plus'))
+    if xen_kernel:
+        message.sub_debug('Xen kernel', xen_kernel)
+        misc.copy_file(xen_kernel, \
+            misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(xen_kernel)))
+    if xen_efi:
+        message.sub_debug('Xen EFI kernel', xen_efi)
+        misc.copy_file(xen_efi, \
+            misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(xen_efi)))
+    if ipxe_kernel:
+        message.sub_debug('iPXE kernel', ipxe_kernel)
+        misc.copy_file(ipxe_kernel, \
+            misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(ipxe_kernel)))
+    if ipxe_efi:
+        message.sub_debug('iPXE EFI kernel', ipxe_efi)
+        misc.copy_file(ipxe_efi, \
+            misc.join_paths(config.ISO_DIR, 'casper/' + os.path.basename(ipxe_efi)))
 
     message.sub_info('Extracting casper UUID')
     confdir = config.FILESYSTEM_DIR + '/conf'


### PR DESCRIPTION
Working from my past local improvements to ubuntu-builder, I've ported them to customizer, as I prefer python.
https://github.com/kamilion/kamikazi-deploy/blob/master/resources/buildscripts/Build.patched-for-xen

Fixes in this commit:
If EFI is determined to be in use, vmlinuz will be hardlinked to vmlinuz.efi, saving a few megs on the ISO.
If found, a Xen kernel will be added to the media in the correct place. Same for ipxe and memtest86+ soon?
As a fix for ubuntu-mini-remix's integrity check, a SHA256SUMS file will be regenerated if found.
This should shore up UMR in respect to #76, outside of the memtest86+ issue, which we can fix.
Compression parameters are now separated from mksquashfs, and a default blocksize of ~1MB is applied.
Editing this can be added to the GUI later, for now, xz's branch-call-jump filters were enabled for x86 code.
In addition, Many comments were added to clarify sections of the ISO rebuild code.
