### PR TITLE
Cleanup and Python 3 support

### DIFF
--- a/src/actions/rebuild.py
+++ b/src/actions/rebuild.py
@@ -256,10 +256,8 @@ def main():
                 continue
             if sfile.endswith('SHA256SUMS'):
                 continue
-
-            # FIXME: read in chunks
             message.sub_debug('MD5 Checksumming', sfile)
-            checksum = hashlib.md5(misc.read_file(sfile)).hexdigest()
+            checksum = misc.generate_hash_for_file('md5', sfile)
             misc.append_file(md5sums_file, checksum + '  .' + \
                 sfile.replace(config.ISO_DIR, '') +'\n')
 
@@ -273,10 +271,8 @@ def main():
                 continue
             if sfile.endswith('SHA256SUMS'):
                 continue
-
-            # FIXME: read in chunks
             message.sub_debug('SHA256 Checksumming', sfile)
-            checksum = hashlib.sha256(misc.read_file(sfile)).hexdigest()
+            checksum = misc.generate_hash_for_file('sha256', sfile)
             misc.append_file(shasums_file, checksum + '  .' + \
                 sfile.replace(config.ISO_DIR, '') +'\n')
 
@@ -290,15 +286,15 @@ def main():
         '-cache-inodes', '-input-charset', 'utf-8', '.'))
 
     message.sub_info('Creating ISO checksums')
-    md5checksum = hashlib.md5(misc.read_file(iso_file)).hexdigest()
+    md5checksum = misc.generate_hash_for_file('md5', isofile)
     message.sub_info('ISO md5 checksum', md5checksum)
     misc.append_file(md5sum_iso_file, md5checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')
-    sha1checksum = hashlib.sha1(misc.read_file(iso_file)).hexdigest()
+    sha1checksum = misc.generate_hash_for_file('sha1', isofile)
     message.sub_info('ISO sha1 checksum', sha1checksum)
     misc.append_file(sha1sum_iso_file, sha1checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')
-    sha256checksum = hashlib.sha256(misc.read_file(iso_file)).hexdigest()
+    sha256checksum = misc.generate_hash_for_file('sha256', isofile)
     message.sub_info('ISO sha256 checksum', sha256checksum)
     misc.append_file(sha256sum_iso_file, sha256checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')

--- a/src/actions/rebuild.py
+++ b/src/actions/rebuild.py
@@ -286,15 +286,15 @@ def main():
         '-cache-inodes', '-input-charset', 'utf-8', '.'))
 
     message.sub_info('Creating ISO checksums')
-    md5checksum = misc.generate_hash_for_file('md5', isofile)
+    md5checksum = misc.generate_hash_for_file('md5', iso_file)
     message.sub_info('ISO md5 checksum', md5checksum)
     misc.append_file(md5sum_iso_file, md5checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')
-    sha1checksum = misc.generate_hash_for_file('sha1', isofile)
+    sha1checksum = misc.generate_hash_for_file('sha1', iso_file)
     message.sub_info('ISO sha1 checksum', sha1checksum)
     misc.append_file(sha1sum_iso_file, sha1checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')
-    sha256checksum = misc.generate_hash_for_file('sha256', isofile)
+    sha256checksum = misc.generate_hash_for_file('sha256', iso_file)
     message.sub_info('ISO sha256 checksum', sha256checksum)
     misc.append_file(sha256sum_iso_file, sha256checksum + '  .' + \
         iso_file.replace(config.WORK_DIR, '') +'\n')

--- a/src/actions/rebuild.py
+++ b/src/actions/rebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
 
-import sys, os, glob, shutil, re, hashlib
+import sys, os, glob, shutil, re
 
 import lib.misc as misc
 import lib.config as config

--- a/src/actions/xnest.py
+++ b/src/actions/xnest.py
@@ -27,7 +27,7 @@ def main():
     x = subprocess.Popen((misc.whereis('Xephyr'), '-ac', '-screen', \
         config.RESOLUTION, '-br', ':13'))
     x.poll()
-    if x.returncode > 0:
+    if x.returncode is not None and x.returncode > 0:
         raise(message.exception('Failed to start Xephyr', x.returncode))
 
     try:

--- a/src/gui.py.in
+++ b/src/gui.py.in
@@ -45,7 +45,7 @@ def msg_warning(msg):
     QtGui.QMessageBox.warning(MainWindow, app.tr('Warning'), msg)
 
 def msg_critical(msg):
-    QtGui.QMessageBox.critical(MainWindow, app.tr('Critical'), str(msg).decode('utf-8'))
+    QtGui.QMessageBox.critical(MainWindow, app.tr('Critical'), u''.format(msg))
 
 # limit instances to one
 lock = '/run/lock/customizer'
@@ -66,7 +66,6 @@ else:
 
 if int(sys.version_info[0]) >= 3:
     msg_critical(app.tr('You are attempting to run Customizer with Python 3.'))
-    sys.exit()
 
 class Thread(QtCore.QThread):
     ''' Worker thread '''
@@ -192,7 +191,8 @@ def change_value(sec, var, val):
         conf = open('/etc/customizer.conf', 'w')
         if not config.conf.has_section(sec):
             config.conf.add_section(sec)
-        config.conf.set(sec, var, val.encode('utf-8'))
+        config.conf.set(sec, var, u'{}'.format(val))
+        message.debug('Writing Configuration file', '/etc/customizer.conf')
         config.conf.write(conf)
     except Exception as detail:
         msg_critical(detail)
@@ -233,7 +233,7 @@ def run_extract():
         config.ISO, app.tr('ISO Files (*.iso);;All Files (*)'))
     if not sfile:
         return
-    sfile = unicode(sfile)
+    sfile = u'{}'.format(sfile)
     change_value('saved', 'iso', sfile)
     extract.config.ISO = sfile
     message.sub_debug('Extracting ISO', sfile)
@@ -283,7 +283,7 @@ def run_deb():
             config.DEB, app.tr('Deb Files (*.deb);;All Files (*)'))
         if not sfile:
             return
-        sfile = unicode(sfile)
+        sfile = u'{}'.format(sfile)
         change_value('saved', 'deb', sfile)
         deb.config.DEB = sfile
         message.sub_debug('Installing DEB package', sfile)
@@ -301,7 +301,7 @@ def run_hook():
             config.HOOK, app.tr('Shell Scripts (*.sh);;All Files (*)'))
         if not sfile:
             return
-        sfile = unicode(sfile)
+        sfile = u'{}'.format(sfile)
         change_value('saved', 'hook', sfile)
         hook.config.HOOK = sfile
         message.sub_debug('Attempting to run hook', sfile)
@@ -330,7 +330,7 @@ def run_qemu():
 def change_user():
     message.sub_debug('Attempting to change username...')
     try:
-        value = unicode(ui.userEdit.text())
+        value = u'{}'.format(ui.userEdit.text())
         if not value.strip():
             msg_critical(app.tr('Live user can not be empty.'))
             ui.userEdit.setText('ubuntu')
@@ -344,7 +344,7 @@ def change_hostname():
     message.sub_debug('Attempting to change hostname...')
     try:
         common.set_value(misc.join_paths(config.FILESYSTEM_DIR, \
-            'etc/casper.conf'), 'export HOST=', unicode(ui.hostnameEdit.text()))
+            'etc/casper.conf'), 'export HOST=', u'{}'.format(ui.hostnameEdit.text()))
     except Exception as detail:
         msg_critical(detail)
 
@@ -355,7 +355,7 @@ def change_work_dir():
             'Directory', config.WORK_DIR)
         if not spath:
             return
-        spath = unicode(spath)
+        spath = u'{}'.format(spath)
         change_value('preferences', 'work_dir', spath)
         ui.workDirEdit.setText(spath)
     except Exception as detail:
@@ -363,22 +363,22 @@ def change_work_dir():
 
 def change_locales():
     message.sub_debug('Attempting to change Locales...')
-    current = unicode(ui.localesBox.currentText())
+    current = u'{}'.format(ui.localesBox.currentText())
     change_value('preferences', 'locales', current)
 
 def change_resolution():
     message.sub_debug('Attempting to change qemu resolution...')
-    current = unicode(ui.resolutionBox.currentText())
+    current = u'{}'.format(ui.resolutionBox.currentText())
     change_value('preferences', 'resolution', current)
 
 def change_vram():
     message.sub_debug('Attempting to change qemu VRAM size...')
-    current = unicode(ui.vramBox.currentText())
+    current = u'{}'.format(ui.vramBox.currentText())
     change_value('preferences', 'vram', current)
 
 def change_compression():
     message.sub_debug('Attempting to change compression type...')
-    current = unicode(ui.compressionBox.currentText())
+    current = u'{}'.format(ui.compressionBox.currentText())
     change_value('preferences', 'compression', current)
 
 def browse_dir(sdir):

--- a/src/gui.py.in
+++ b/src/gui.py.in
@@ -304,7 +304,7 @@ def run_hook():
         sfile = unicode(sfile)
         change_value('saved', 'hook', sfile)
         hook.config.HOOK = sfile
-            message.sub_debug('Attempting to run hook', sfile)
+        message.sub_debug('Attempting to run hook', sfile)
         worker(hook.main)
     except Exception as detail:
         msg_critical(detail)

--- a/src/gui.py.in
+++ b/src/gui.py.in
@@ -4,7 +4,7 @@
 # This is quick and dirty written GUI! #
 ############### END NOTE ###############
 
-import sys, os, atexit, subprocess
+import sys, os, atexit, subprocess, imp
 sys.path.append("@PREFIX@/share/customizer")
 
 import gui_ui
@@ -199,7 +199,7 @@ def change_value(sec, var, val):
     finally:
         if conf:
             conf.close()
-        reload(config)
+        imp.reload(config)
 
 def worker_started():
     ui.progressBar.setRange(0, 0)

--- a/src/gui.py.in
+++ b/src/gui.py.in
@@ -12,6 +12,7 @@ from PyQt4 import QtCore, QtGui
 
 import lib.config as config
 import lib.misc as misc
+import lib.message as message
 import actions.common as common
 import actions.extract as extract
 import actions.deb as deb
@@ -153,18 +154,21 @@ def setup_gui():
         ui.extraCustomizationBox.setEnabled(False)
 
 def run_core(args, terminal=True):
+    message.sub_debug('GUI Running', 'customizer ' + args)
     if terminal:
         terminal = None
         for term in ('xterm', 'lxterminal', 'xfce4-terminal', 'terminal',
             'konsole', 'mate-terminal', 'gnome-terminal', 'terminator', \
-            'sakura', 'urxterm', 'aterm', 'Eterm'):
+            'sakura', 'urxterm', 'aterm', 'Eterm', 'x-terminal-emulator'):
             spath = misc.whereis(term)
             if spath:
                 terminal = spath
+                message.sub_debug('Found terminal', terminal)
 
         if not terminal:
             msg_critical(app.tr('No supported terminal emulator detected.'))
             return
+    message.sub_debug('Selected last found terminal', terminal)
 
     try:
         if terminal and terminal.endswith('konsole'):
@@ -232,24 +236,28 @@ def run_extract():
     sfile = unicode(sfile)
     change_value('saved', 'iso', sfile)
     extract.config.ISO = sfile
+    message.sub_debug('Extracting ISO', sfile)
     try:
         worker(extract.main)
     except Exception as detail:
         msg_critical(detail)
 
 def run_rebuild():
+    message.sub_debug('Starting Rebuild...')
     try:
         worker(rebuild.main)
     except Exception as detail:
         msg_critical(detail)
 
 def run_clean():
+    message.sub_debug('Starting Cleaning...')
     try:
         worker(clean.main)
     except Exception as detail:
         msg_critical(detail)
 
 def edit_sources():
+    message.sub_debug('Trying to edit sources...')
     editor = None
     for edit in ('mousepad', 'leafpad', 'pluma', 'gedit', 'kate', 'kwrite', \
         'medit', 'nedit', 'geany', 'bluefish', 'ultraedit'):
@@ -278,11 +286,13 @@ def run_deb():
         sfile = unicode(sfile)
         change_value('saved', 'deb', sfile)
         deb.config.DEB = sfile
+        message.sub_debug('Installing DEB package', sfile)
         worker(deb.main)
     except Exception as detail:
         msg_critical(detail)
 
 def run_pkgm():
+    message.sub_debug('Starting Graphical Package Manager...')
     run_core('-p')
 
 def run_hook():
@@ -294,26 +304,31 @@ def run_hook():
         sfile = unicode(sfile)
         change_value('saved', 'hook', sfile)
         hook.config.HOOK = sfile
+            message.sub_debug('Attempting to run hook', sfile)
         worker(hook.main)
     except Exception as detail:
         msg_critical(detail)
 
 def run_chroot():
+    message.sub_debug('Opening terminal...')
     run_core('-c')
 
 def run_xnest():
+    message.sub_debug('Opening Nested GUI Desktop...')
     try:
         worker(xnest.main)
     except Exception as detail:
         msg_critical(detail)
 
 def run_qemu():
+    message.sub_debug('Starting qemu...')
     try:
         worker(qemu.main)
     except Exception as detail:
         msg_critical(detail)
 
 def change_user():
+    message.sub_debug('Attempting to change username...')
     try:
         value = unicode(ui.userEdit.text())
         if not value.strip():
@@ -326,6 +341,7 @@ def change_user():
         msg_critical(detail)
 
 def change_hostname():
+    message.sub_debug('Attempting to change hostname...')
     try:
         common.set_value(misc.join_paths(config.FILESYSTEM_DIR, \
             'etc/casper.conf'), 'export HOST=', unicode(ui.hostnameEdit.text()))
@@ -333,6 +349,7 @@ def change_hostname():
         msg_critical(detail)
 
 def change_work_dir():
+    message.sub_debug('Attempting to change hostname...')
     try:
         spath = QtGui.QFileDialog.getExistingDirectory(MainWindow, \
             'Directory', config.WORK_DIR)
@@ -345,22 +362,27 @@ def change_work_dir():
         msg_critical(detail)
 
 def change_locales():
+    message.sub_debug('Attempting to change Locales...')
     current = unicode(ui.localesBox.currentText())
     change_value('preferences', 'locales', current)
 
 def change_resolution():
+    message.sub_debug('Attempting to change qemu resolution...')
     current = unicode(ui.resolutionBox.currentText())
     change_value('preferences', 'resolution', current)
 
 def change_vram():
+    message.sub_debug('Attempting to change qemu VRAM size...')
     current = unicode(ui.vramBox.currentText())
     change_value('preferences', 'vram', current)
 
 def change_compression():
+    message.sub_debug('Attempting to change compression type...')
     current = unicode(ui.compressionBox.currentText())
     change_value('preferences', 'compression', current)
 
 def browse_dir(sdir):
+    message.sub_debug('Attempting to open GUI file browser for', sdir)
     try:
         manager = None
         for term in ('dolphin', 'thunar', 'pcmanfm', 'nautilus', 'emelfm', \

--- a/src/lib/config.py
+++ b/src/lib/config.py
@@ -1,6 +1,10 @@
 #!/usr/bin/python2
 
-import os, ConfigParser
+import os
+try:  # Importing python3 style first.
+    import configparser as ConfigParser
+except:  # Fall back to python2.
+    import ConfigParser
 
 import lib.message as message
 
@@ -18,22 +22,24 @@ conf = ConfigParser.SafeConfigParser(
 )
 
 if not os.path.isfile('/etc/customizer.conf'):
-    message.warning('Configuration file does not exists', '/etc/customizer.conf')
+    message.warning('Configuration file does not exist', '/etc/customizer.conf')
 
 conf.read('/etc/customizer.conf')
+message.info('Read Configuration file', '/etc/customizer.conf')
 for section in ('preferences', 'saved'):
     if not conf.has_section(section):
         conf.add_section(section)
 
-WORK_DIR = conf.get('preferences', 'WORK_DIR')
-LOCALES = conf.get('preferences', 'LOCALES')
-RESOLUTION = conf.get('preferences', 'RESOLUTION')
-COMPRESSION = conf.get('preferences', 'COMPRESSION')
-VRAM = conf.get('preferences', 'VRAM')
+# Make sure these end up to be strings in both python2 and python3.
+WORK_DIR = '{}'.format(conf.get('preferences', 'WORK_DIR'))
+LOCALES = '{}'.format(conf.get('preferences', 'LOCALES'))
+RESOLUTION = '{}'.format(conf.get('preferences', 'RESOLUTION'))
+COMPRESSION = '{}'.format(conf.get('preferences', 'COMPRESSION'))
+VRAM = '{}'.format(conf.get('preferences', 'VRAM'))
 
-ISO = conf.get('saved', 'ISO')
-DEB = conf.get('saved', 'DEB')
-HOOK = conf.get('saved', 'HOOK')
+ISO = '{}'.format(conf.get('saved', 'ISO'))
+DEB = '{}'.format(conf.get('saved', 'DEB'))
+HOOK = '{}'.format(conf.get('saved', 'HOOK'))
 
 MOUNT_DIR = '/media'
 FILESYSTEM_DIR = os.path.join(WORK_DIR, 'FileSystem')

--- a/src/lib/message.py
+++ b/src/lib/message.py
@@ -4,7 +4,7 @@ import sys
 import curses
 
 tty_colors = 0
-DEBUG = True
+DEBUG = False
 
 try:
     curses.setupterm()

--- a/src/lib/message.py
+++ b/src/lib/message.py
@@ -4,7 +4,7 @@ import sys
 import curses
 
 tty_colors = 0
-DEBUG = False
+DEBUG = True
 
 try:
     curses.setupterm()

--- a/src/lib/message.py
+++ b/src/lib/message.py
@@ -47,75 +47,75 @@ else:
 def info(msg, marker=None):
     ''' Print message with INFO status '''
     if not marker is None:
-        print('%s* %s%s: %s%s%s' % \
-            (cmarker, cnormal, msg, cinfo, marker, cnormal))
+        print('{}* {}{}: {}{}{}'.format( \
+            cmarker, cnormal, msg, cinfo, marker, cnormal))
     else:
-        print('%s* %s%s' % (cmarker, cnormal, msg))
+        print('{}* {}{}'.format(cmarker, cnormal, msg))
 
 
 def warning(msg, marker=None):
     ''' Print message with WARNING status '''
     if not marker is None:
-        sys.stderr.write('%s* %s%s: %s%s%s\n' % \
-            (cwarning, cnormal, msg, cwarning, marker, cnormal))
+        sys.stderr.write('{}* {}{}: {}{}{}\n'.format( \
+            cwarning, cnormal, msg, cwarning, marker, cnormal))
     else:
-        sys.stderr.write('%s* %s%s\n' % (cwarning, cnormal, msg))
+        sys.stderr.write('{}* {}{}\n'.format(cwarning, cnormal, msg))
 
 
 def critical(msg, marker=None):
     ''' Print message with CRITICAL status '''
     if not marker is None:
-        sys.stderr.write('%s* %s%s: %s%s%s\n' % \
-            (ccritical, cnormal, msg, ccritical, marker, cnormal))
+        sys.stderr.write('{}* {}{}: {}{}{}\n'.format( \
+            ccritical, cnormal, msg, ccritical, marker, cnormal))
     else:
-        sys.stderr.write('%s* %s%s\n' % (ccritical, cnormal, msg))
+        sys.stderr.write('{}* {}{}\n'.format(ccritical, cnormal, msg))
 
 
 def debug(msg, marker=None):
     ''' Print message with DEBUG status '''
     if DEBUG:
         if not marker is None:
-            print('%s* %s%s: %s%s%s' % \
-                (cdebug, cnormal, msg, cdebug, marker, cnormal))
+            print('{}* {}{}: {}{}{}'.format( \
+                cdebug, cnormal, msg, cdebug, marker, cnormal))
         else:
-            print('%s* %s%s' % (cdebug, cnormal, msg))
+            print('{}* {}{}'.format(cdebug, cnormal, msg))
 
 
 def sub_info(msg, marker=None):
     ''' Print sub-message with INFO status '''
     if not marker is None:
-        print('%s  => %s%s: %s%s%s' % \
-            (cmarker, cnormal, msg, cinfo, marker, cnormal))
+        print('{}  => {}{}: {}{}{}'.format( \
+            cmarker, cnormal, msg, cinfo, marker, cnormal))
     else:
-        print('%s  => %s%s' % (cmarker, cnormal, msg))
+        print('{}  => {}{}'.format(cmarker, cnormal, msg))
 
 
 def sub_warning(msg, marker=None):
     ''' Print sub-message with WARNING status '''
     if not marker is None:
-        sys.stderr.write('%s  => %s%s: %s%s%s\n' % \
-            (cwarning, cnormal, msg, cwarning, marker, cnormal))
+        sys.stderr.write('{}  => {}{}: {}{}{}\n'.format( \
+            cwarning, cnormal, msg, cwarning, marker, cnormal))
     else:
-        sys.stderr.write('%s  => %s%s\n' % (cwarning, cnormal, msg))
+        sys.stderr.write('{}  => {}{}\n'.format(cwarning, cnormal, msg))
 
 
 def sub_critical(msg, marker=None):
     ''' Print sub-message with CRITICAL status '''
     if not marker is None:
-        sys.stderr.write('%s  => %s%s: %s%s%s\n' % \
-            (ccritical, cnormal, msg, ccritical, marker, cnormal))
+        sys.stderr.write('{}  => {}{}: {}{}{}\n'.format( \
+            ccritical, cnormal, msg, ccritical, marker, cnormal))
     else:
-        sys.stderr.write('%s  => %s%s\n' % (ccritical, cnormal, msg))
+        sys.stderr.write('{}  => {}{}\n'.format(ccritical, cnormal, msg))
 
 
 def sub_debug(msg, marker=None):
     ''' Print sub-message with DEBUG status '''
     if DEBUG:
         if not marker is None:
-            print('%s  => %s%s: %s%s%s' % \
-                (cdebug, cnormal, msg, cdebug, marker, cnormal))
+            print('{}  => {}{}: {}{}{}'.format( \
+			cdebug, cnormal, msg, cdebug, marker, cnormal))
         else:
-            print('%s  => %s%s' % (cdebug, cnormal, msg))
+            print('{}  => {}{}'.format(cdebug, cnormal, msg))
 
 class exception(Exception):
     pass

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -2,6 +2,12 @@
 
 import os, re, shutil, shlex, subprocess
 
+import lib.message as message
+CMD_DEBUG = True
+COPY_DEBUG = True
+CHROOT_DEBUG = True
+MOUNT_DEBUG = True
+
 import lib.config as config
 CATCH = False
 
@@ -28,6 +34,15 @@ def join_paths(*paths):
     for p in paths:
         result = os.path.join(result, p.lstrip('/'))
     return os.path.normpath(result)
+
+def join_work_path(*paths):
+    return join_paths(config.WORK_DIR, paths)
+
+def join_iso_path(*paths):
+    return join_paths(config.ISO_DIR, paths)
+
+def join_fs_path(*paths):
+    return join_paths(config.FILESYSTEM_DIR, paths)
 
 
 ''' File operations '''
@@ -71,6 +86,7 @@ def append_file(sfile, content):
     afile.close()
 
 def copy_file(source, destination):
+    if COPY_DEBUG: message.sub_debug('File {} copied to'.format(source), destination)
     base = os.path.dirname(destination)
     if not os.path.isdir(base):
         os.makedirs(base)
@@ -93,9 +109,11 @@ def search_string(string, string2, exact=False, escape=True):
         return re.findall(string, str(string2))
 
 def search_file(string, sfile, exact=False, escape=True):
+    if CMD_DEBUG: message.sub_debug('Searching {} for'.format(sfile), string)
     return search_string(string, read_file(sfile), exact=exact, escape=escape)
 
 def list_files(directory):
+    if CMD_DEBUG: message.sub_debug('Listing files in', directory)
     slist = []
     if not os.path.exists(directory):
         return slist
@@ -112,6 +130,7 @@ def dir_current():
     return cwd
 
 def system_command(command, shell=False, cwd=None, env=None):
+    if CMD_DEBUG: message.sub_debug('Executing system command', command)
     if not cwd:
         cwd = dir_current()
     elif not os.path.isdir(cwd):
@@ -131,19 +150,21 @@ def system_command(command, shell=False, cwd=None, env=None):
         return subprocess.check_call(command, shell=shell, cwd=cwd, env=env)
 
 def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, shell=False, cwd=None):
+    if CHROOT_DEBUG: message.sub_debug('Trying to set up chroot command', command)
     out = None
-    resolv = '%s/etc/resolv.conf' % config.FILESYSTEM_DIR
-    hosts = '%s/etc/hosts' % config.FILESYSTEM_DIR
+    resolv = '{}/etc/resolv.conf'.format(config.FILESYSTEM_DIR)
+    hosts = '{}/etc/hosts'.format(config.FILESYSTEM_DIR)
     mount = whereis('mount')
     umount = whereis('umount')
     chroot = whereis('chroot')
     if isinstance(command, str):
-        chroot_command = '%s %s %s' % (chroot, config.FILESYSTEM_DIR, command)
+        chroot_command = '{} {} {}'.format(chroot, config.FILESYSTEM_DIR, command)
     else:
         chroot_command = [chroot, config.FILESYSTEM_DIR]
         chroot_command.extend(command)
     try:
         if prepare:
+            if CHROOT_DEBUG: message.sub_debug('Preparing chroot environment for networking')
             if os.path.isfile('/etc/resolv.conf') and not os.path.islink(resolv):
                  copy_file('/etc/resolv.conf', resolv)
             elif os.path.islink(resolv):
@@ -155,10 +176,11 @@ def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, sh
                 copy_file('/etc/resolv.conf', resolv)
             if os.path.isfile('/etc/hosts'):
                 if os.path.isfile(hosts):
-                    copy_file(hosts, '%s.backup' % hosts)
+                    copy_file(hosts, '{}.backup'.format(hosts))
                 copy_file('/etc/hosts', hosts)
 
         if mount:
+            if CHROOT_DEBUG: message.sub_debug('Mounting paths inside chroot')
             pseudofs = ['/proc', '/dev', '/dev/pts', '/dev/shm', '/sys', '/tmp', '/var/lib/dbus']
             if os.path.islink(config.FILESYSTEM_DIR + '/var/run'):
                 pseudofs.append('/run/dbus')
@@ -171,17 +193,20 @@ def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, sh
                 if not os.path.ismount(sdir):
                     if not os.path.isdir(sdir):
                         os.makedirs(sdir)
+                    if MOUNT_DEBUG: message.sub_debug('Mounting --bind {}'.format(s), sdir)
                     system_command((mount, '--bind', s, sdir))
 
 
         if prepare:
-            mtab = '%s/etc/mtab' % config.FILESYSTEM_DIR
+            if MOUNT_DEBUG: message.sub_debug('Creating mtab inside chroot')
+            mtab = '{}/etc/mtab'.format(config.FILESYSTEM_DIR)
             if not os.path.isfile(mtab) and not os.path.islink(mtab):
                 os.symlink('../../proc/mounts', mtab)
 
         if not config.LOCALES == 'C':
             system_command(('locale-gen', config.LOCALES))
 
+        if CHROOT_DEBUG: message.sub_debug('Enumerating environment variables')
         # all operations on reference to os.environ change the environment!
         environment = {}
         for item in os.environ:
@@ -212,19 +237,25 @@ def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, sh
             environment['DEBCONF_NOWARNINGS'] = 'true'
 
         if output:
+            if CHROOT_DEBUG: message.sub_debug('Entering chroot')
             out = get_output(chroot_command)
+            if CHROOT_DEBUG: message.sub_debug('Exiting chroot')
         else:
+            if CHROOT_DEBUG: message.sub_debug('Entering chroot')
             system_command(chroot_command, shell=shell, \
                 env=environment, cwd=cwd)
+            if CHROOT_DEBUG: message.sub_debug('Exiting chroot')
     finally:
         if prepare:
-            if os.path.isfile('%s.backup' % hosts):
-                copy_file('%s.backup' % hosts, hosts)
-                os.unlink('%s.backup' % hosts)
+            if os.path.isfile('{}.backup'.format(hosts)):
+                copy_file('{}.backup'.format(hosts), hosts)
+                os.unlink('{}.backup'.format(hosts))
         if mount:
             for s in reversed(pseudofs):
                 sdir = config.FILESYSTEM_DIR + s
                 if os.path.ismount(sdir):
+                    if MOUNT_DEBUG: message.sub_debug('Unmounting -f -l', sdir)
                     system_command((umount, '-f', '-l', sdir))
+        system_command(('sleep', '3'))
     if output:
         return out

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
 
-import os, re, shutil, shlex, subprocess, time
+import os, re, shutil, shlex, subprocess, time, hashlib
 
 import lib.message as message
 CMD_DEBUG = True

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -1,11 +1,12 @@
 #!/usr/bin/python2
 
-import os, re, shutil, shlex, subprocess
+import os, re, shutil, shlex, subprocess, time
 
 import lib.message as message
 CMD_DEBUG = True
 COPY_DEBUG = True
 CHROOT_DEBUG = True
+FILE_DEBUG = True
 MOUNT_DEBUG = True
 
 import lib.config as config
@@ -47,18 +48,21 @@ def join_fs_path(*paths):
 
 ''' File operations '''
 def read_file(sfile):
+    if FILE_DEBUG: message.sub_debug('Reading entire file', sfile)
     rfile = open(sfile, 'r')
     content = rfile.read()
     rfile.close()
     return content
 
 def readlines_file(sfile):
+    if FILE_DEBUG: message.sub_debug('Reading lines from', sfile)
     rfile = open(sfile, 'r')
     content = rfile.readlines()
     rfile.close()
     return content
 
 def write_file(sfile, content):
+    if FILE_DEBUG: message.sub_debug('Writing data to', sfile)
     dirname = os.path.dirname(sfile)
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
@@ -77,6 +81,7 @@ def write_file(sfile, content):
         wfile.close()
 
 def append_file(sfile, content):
+    if FILE_DEBUG: message.sub_debug('Appending data to', sfile)
     dirname = os.path.dirname(sfile)
     if not os.path.isdir(dirname):
         os.makedirs(dirname)
@@ -130,7 +135,7 @@ def dir_current():
     return cwd
 
 def system_command(command, shell=False, cwd=None, env=None):
-    if CMD_DEBUG: message.sub_debug('Executing system command', command)
+    message.sub_debug('Executing system command', command)
     if not cwd:
         cwd = dir_current()
     elif not os.path.isdir(cwd):
@@ -256,6 +261,7 @@ def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, sh
                 if os.path.ismount(sdir):
                     if MOUNT_DEBUG: message.sub_debug('Unmounting -f -l', sdir)
                     system_command((umount, '-f', '-l', sdir))
-        system_command(('sleep', '3'))
+            time.sleep(0.1)  # Wait for lazy unmounts to unlazy...
+        system_command(('sleep', '1')) # Make sure of it. (and log it)
     if output:
         return out

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -3,11 +3,10 @@
 import os, re, shutil, shlex, subprocess, time, hashlib
 
 import lib.message as message
-CMD_DEBUG = True
-COPY_DEBUG = True
+CMD_DEBUG = False
 CHROOT_DEBUG = True
-FILE_DEBUG = True
-MOUNT_DEBUG = True
+FILE_DEBUG = False
+MOUNT_DEBUG = False
 
 import lib.config as config
 CATCH = False
@@ -91,7 +90,7 @@ def append_file(sfile, content):
     afile.close()
 
 def copy_file(source, destination):
-    if COPY_DEBUG: message.sub_debug('File {} copied to'.format(source), destination)
+    if FILE_DEBUG: message.sub_debug('File {} copied to'.format(source), destination)
     base = os.path.dirname(destination)
     if not os.path.isdir(base):
         os.makedirs(base)
@@ -124,11 +123,11 @@ def search_string(string, string2, exact=False, escape=True):
         return re.findall(string, str(string2))
 
 def search_file(string, sfile, exact=False, escape=True):
-    if CMD_DEBUG: message.sub_debug('Searching {} for'.format(sfile), string)
+    if FILE_DEBUG: message.sub_debug('Searching {} for'.format(sfile), string)
     return search_string(string, read_file(sfile), exact=exact, escape=escape)
 
 def list_files(directory):
-    if CMD_DEBUG: message.sub_debug('Listing files in', directory)
+    if FILE_DEBUG: message.sub_debug('Listing files in', directory)
     slist = []
     if not os.path.exists(directory):
         return slist
@@ -145,7 +144,7 @@ def dir_current():
     return cwd
 
 def system_command(command, shell=False, cwd=None, env=None):
-    message.sub_debug('Executing system command', command)
+    if CMD_DEBUG: message.sub_debug('Executing system command', command)
     if not cwd:
         cwd = dir_current()
     elif not os.path.isdir(cwd):

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -4,7 +4,7 @@ import os, re, shutil, shlex, subprocess, time, hashlib
 
 import lib.message as message
 CMD_DEBUG = False
-CHROOT_DEBUG = True
+CHROOT_DEBUG = False
 FILE_DEBUG = False
 MOUNT_DEBUG = False
 

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -97,6 +97,16 @@ def copy_file(source, destination):
         os.makedirs(base)
     shutil.copyfile(source, destination)
 
+def generate_hash_for_file(hashtype, filename, blocksize=2**20):
+    m = hashlib.new(hashtype)
+    with open(filename, "rb") as f:
+        while True:
+            buf = f.read(blocksize)
+            if not buf:
+                break
+            m.update(buf)
+    return m.hexdigest()
+
 ''' System operations '''
 def get_output(command):
     pipe = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/src/lib/misc.py
+++ b/src/lib/misc.py
@@ -219,7 +219,7 @@ def chroot_exec(command, prepare=True, mount=True, output=False, xnest=False, sh
                 os.symlink('../../proc/mounts', mtab)
             if not os.path.isfile(inhibit):
                 write_file(inhibit, "exit 101")
-                os.chmod(inhibit, 0755)
+                os.chmod(inhibit, 0o755)
         
         if not config.LOCALES == 'C':
             system_command(('locale-gen', config.LOCALES))

--- a/src/main.py.in
+++ b/src/main.py.in
@@ -24,7 +24,7 @@ try:
     parser = argparse.ArgumentParser(prog='Customizer', \
         description='Ubuntu based LiveCD ISO images remastering tool')
     parser.add_argument('-e', '--extract', action='store_true', \
-        help='Exctract ISO image')
+        help='Extract ISO image')
     parser.add_argument('-c', '--chroot', action='store_true', \
         help='Chroot into the filesystem')
     parser.add_argument('-x', '--xnest', action='store_true', \
@@ -38,7 +38,7 @@ try:
     parser.add_argument('-r', '--rebuild', action='store_true', \
         help='Rebuild the ISO image')
     parser.add_argument('-q', '--qemu', action='store_true', \
-        help='Test the builded image with QEMU')
+        help='Test the built ISO image with QEMU')
     parser.add_argument('-t', '--clean', action='store_true', \
         help='Clean all temporary files and folders')
     parser.add_argument('-D', '--debug', nargs=0, action=OverrideDebug, \

--- a/tr/customizer_bg_BG.ts
+++ b/tr/customizer_bg_BG.ts
@@ -301,12 +301,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
         <translation>Опитвате се да стартирате Customizer с Python 3.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="146"/>
+        <location filename="gui.py" line="145"/>
         <source>The filesystem is not valid or corrupted. Clean is recommended.</source>
         <translation>Файловата система не е валидна или е повредена. Изчистване е препоръчително.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="169"/>
+        <location filename="gui.py" line="168"/>
         <source>No supported terminal emulator detected.</source>
         <translation>Не е намерен терминал, който се поддържа.</translation>
     </message>

--- a/tr/customizer_bg_BG.ts
+++ b/tr/customizer_bg_BG.ts
@@ -3,217 +3,212 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="gui_ui.py" line="215"/>
+        <location filename="gui_ui.py" line="225"/>
         <source>Customizer GUI</source>
         <translation>Customizer ГПИ</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="216"/>
+        <location filename="gui_ui.py" line="226"/>
         <source>Select ISO</source>
         <translation>Избери ISO</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="217"/>
+        <location filename="gui_ui.py" line="227"/>
         <source>Rebuild ISO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="218"/>
+        <location filename="gui_ui.py" line="228"/>
         <source>QEMU</source>
         <translation>QEMU</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="219"/>
+        <location filename="gui_ui.py" line="229"/>
         <source>Clean</source>
         <translation>Изчисти</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="220"/>
+        <location filename="gui_ui.py" line="230"/>
         <source> Customization </source>
         <translation>Персонализации</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="221"/>
+        <location filename="gui_ui.py" line="231"/>
         <source>Edit sources</source>
         <translation>Промени източници</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="222"/>
+        <location filename="gui_ui.py" line="232"/>
         <source>Archive</source>
         <translation>Архив</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="223"/>
+        <location filename="gui_ui.py" line="233"/>
         <source>Install DEB</source>
         <translation>Инсталирай ДЕБ</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="224"/>
+        <location filename="gui_ui.py" line="234"/>
         <source>Terminal</source>
         <translation>Терминал</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="225"/>
+        <location filename="gui_ui.py" line="235"/>
         <source>Desktop</source>
         <translation>Десктоп</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="226"/>
+        <location filename="gui_ui.py" line="236"/>
         <source>Execute hook</source>
         <translation>Изпълни кука</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="227"/>
+        <location filename="gui_ui.py" line="237"/>
         <source> Configuration </source>
         <translation>Конфигурация</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="228"/>
+        <location filename="gui_ui.py" line="238"/>
         <source>Hostname</source>
         <translation>Име на хоста</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="229"/>
+        <location filename="gui_ui.py" line="239"/>
         <source>Live user</source>
         <translation>Жив потребител</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="230"/>
+        <location filename="gui_ui.py" line="240"/>
         <source>Main</source>
         <translation>Основни</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="235"/>
+        <location filename="gui_ui.py" line="245"/>
         <source>X-nest resolution</source>
         <translation>Х-нест резолюция</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="236"/>
+        <location filename="gui_ui.py" line="246"/>
         <source>Change</source>
         <translation>Промени</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="237"/>
+        <location filename="gui_ui.py" line="247"/>
         <source>Working directory</source>
         <translation>Работна директория</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="238"/>
+        <location filename="gui_ui.py" line="248"/>
         <source>QEMU RAM (in MB)</source>
         <translation>QEMU РАМ (в МБ)</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="239"/>
+        <location filename="gui_ui.py" line="249"/>
         <source>C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="240"/>
+        <location filename="gui_ui.py" line="250"/>
         <source>Locales</source>
         <translation>Локализации</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="241"/>
+        <location filename="gui_ui.py" line="251"/>
         <source>64</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="242"/>
+        <location filename="gui_ui.py" line="252"/>
         <source>128</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="243"/>
+        <location filename="gui_ui.py" line="253"/>
         <source>256</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="244"/>
+        <location filename="gui_ui.py" line="254"/>
         <source>512</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="245"/>
+        <location filename="gui_ui.py" line="255"/>
         <source>1024</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="246"/>
+        <location filename="gui_ui.py" line="256"/>
         <source>2048</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="247"/>
+        <location filename="gui_ui.py" line="257"/>
         <source>4086</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="248"/>
+        <location filename="gui_ui.py" line="258"/>
         <source>640x480</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="249"/>
+        <location filename="gui_ui.py" line="259"/>
         <source>800x600</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="250"/>
+        <location filename="gui_ui.py" line="260"/>
         <source>1024x768</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="251"/>
+        <location filename="gui_ui.py" line="261"/>
         <source>SquashFS format</source>
         <translation>SquashFS формат</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="252"/>
+        <location filename="gui_ui.py" line="262"/>
         <source>xz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="253"/>
+        <location filename="gui_ui.py" line="263"/>
         <source>gzip</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="254"/>
+        <location filename="gui_ui.py" line="264"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="255"/>
+        <location filename="gui_ui.py" line="265"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;set on runtime!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="285"/>
-        <source>About</source>
-        <translation>Относно</translation>
-    </message>
-    <message>
-        <location filename="gui_ui.py" line="231"/>
+        <location filename="gui_ui.py" line="241"/>
         <source> Extra Customization </source>
         <translation>Допълнителни персонализации</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="232"/>
+        <location filename="gui_ui.py" line="242"/>
         <source>Browse FileSystem</source>
         <translation>Разгледай FileSystem</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="233"/>
+        <location filename="gui_ui.py" line="243"/>
         <source>Browse ISO</source>
         <translation>Разгледай ISO</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="234"/>
+        <location filename="gui_ui.py" line="244"/>
         <source>Extra</source>
         <translation>Допълнителни</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="256"/>
+        <location filename="gui_ui.py" line="266"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -245,76 +240,108 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Thanks to all who helped making this project useful to this date!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="gui_ui.py" line="295"/>
+        <source>Credits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gui_ui.py" line="296"/>
+        <source>The GNU General Public License version 2 (GPLv2)
+
+Copyright (C) 2010-2013 Ivailo Monev
+Copyright (C) 2013-2015 Mubiin Kimura
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gui_ui.py" line="314"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>app</name>
     <message>
-        <location filename="gui.py" line="41"/>
+        <location filename="gui.py" line="42"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="gui.py" line="44"/>
+        <location filename="gui.py" line="45"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="gui.py" line="47"/>
+        <location filename="gui.py" line="48"/>
         <source>Critical</source>
         <translation>Критично</translation>
     </message>
     <message>
-        <location filename="gui.py" line="60"/>
+        <location filename="gui.py" line="61"/>
         <source>An instance of Customizer is already running.</source>
         <translation>Инстанция на Customizer вече е стартирана.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="67"/>
+        <location filename="gui.py" line="68"/>
         <source>You are attempting to run Customizer with Python 3.</source>
         <translation>Опитвате се да стартирате Customizer с Python 3.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="145"/>
+        <location filename="gui.py" line="146"/>
         <source>The filesystem is not valid or corrupted. Clean is recommended.</source>
         <translation>Файловата система не е валидна или е повредена. Изчистване е препоръчително.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="166"/>
+        <location filename="gui.py" line="169"/>
         <source>No supported terminal emulator detected.</source>
         <translation>Не е намерен терминал, който се поддържа.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="228"/>
+        <location filename="gui.py" line="232"/>
         <source>Open</source>
         <translation>Отвори</translation>
     </message>
     <message>
-        <location filename="gui.py" line="228"/>
+        <location filename="gui.py" line="232"/>
         <source>ISO Files (*.iso);;All Files (*)</source>
         <translation>ISO Файлове (*.iso);;Всички Файлове (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="261"/>
+        <location filename="gui.py" line="269"/>
         <source>No supported text editor detected.</source>
         <translation>Не е намерен текстов редактор, който се поддържа.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="274"/>
+        <location filename="gui.py" line="282"/>
         <source>Deb Files (*.deb);;All Files (*)</source>
         <translation>Deb Файлове (*.deb);;Всички Файлове (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="290"/>
+        <location filename="gui.py" line="300"/>
         <source>Shell Scripts (*.sh);;All Files (*)</source>
         <translation>Скриптове на Обвивката (*.sh);;Всички Файлове (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="374"/>
+        <location filename="gui.py" line="396"/>
         <source>No supported file manager detected.</source>
         <translation>Не е намерен файлов мениджър, който се поддържа.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="320"/>
+        <location filename="gui.py" line="335"/>
         <source>Live user can not be empty.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tr/customizer_ko_KR.ts
+++ b/tr/customizer_ko_KR.ts
@@ -301,12 +301,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
         <translation>당신은 파이썬 3으로 커스터마이저를 실행하려고합니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="146"/>
+        <location filename="gui.py" line="145"/>
         <source>The filesystem is not valid or corrupted. Clean is recommended.</source>
         <translation>파일시스템이 잘못되거나 손상되었습니다. 청소를 하는 것이 좋습니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="169"/>
+        <location filename="gui.py" line="168"/>
         <source>No supported terminal emulator detected.</source>
         <translation>지원되는 터미널 에뮬레이터가 감지 되지 않습니다.</translation>
     </message>

--- a/tr/customizer_ko_KR.ts
+++ b/tr/customizer_ko_KR.ts
@@ -3,217 +3,212 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="gui_ui.py" line="215"/>
+        <location filename="gui_ui.py" line="225"/>
         <source>Customizer GUI</source>
         <translation>커스터마이저 GUI</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="216"/>
+        <location filename="gui_ui.py" line="226"/>
         <source>Select ISO</source>
         <translation>ISO 선택</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="217"/>
+        <location filename="gui_ui.py" line="227"/>
         <source>Rebuild ISO</source>
         <translation type="unfinished">ISO 다시빌드</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="218"/>
+        <location filename="gui_ui.py" line="228"/>
         <source>QEMU</source>
         <translation>QEMU</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="219"/>
+        <location filename="gui_ui.py" line="229"/>
         <source>Clean</source>
         <translation>청소</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="220"/>
+        <location filename="gui_ui.py" line="230"/>
         <source> Customization </source>
         <translation>사용자 지정</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="221"/>
+        <location filename="gui_ui.py" line="231"/>
         <source>Edit sources</source>
         <translation>소스 수정</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="222"/>
+        <location filename="gui_ui.py" line="232"/>
         <source>Archive</source>
         <translation>아카이브</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="223"/>
+        <location filename="gui_ui.py" line="233"/>
         <source>Install DEB</source>
         <translation>DEB 설치</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="224"/>
+        <location filename="gui_ui.py" line="234"/>
         <source>Terminal</source>
         <translation>터미널</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="225"/>
+        <location filename="gui_ui.py" line="235"/>
         <source>Desktop</source>
         <translation>데스크탑</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="226"/>
+        <location filename="gui_ui.py" line="236"/>
         <source>Execute hook</source>
         <translation>후크 실행</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="227"/>
+        <location filename="gui_ui.py" line="237"/>
         <source> Configuration </source>
         <translation>구성</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="228"/>
+        <location filename="gui_ui.py" line="238"/>
         <source>Hostname</source>
         <translation>호스트 이름</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="229"/>
+        <location filename="gui_ui.py" line="239"/>
         <source>Live user</source>
         <translation>라이브 유저</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="230"/>
+        <location filename="gui_ui.py" line="240"/>
         <source>Main</source>
         <translation>메인</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="235"/>
+        <location filename="gui_ui.py" line="245"/>
         <source>X-nest resolution</source>
         <translation>Х-нест 해상도</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="236"/>
+        <location filename="gui_ui.py" line="246"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="237"/>
+        <location filename="gui_ui.py" line="247"/>
         <source>Working directory</source>
         <translation>작업 디렉토리</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="238"/>
+        <location filename="gui_ui.py" line="248"/>
         <source>QEMU RAM (in MB)</source>
         <translation>QEMU 램 (in MB)</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="239"/>
+        <location filename="gui_ui.py" line="249"/>
         <source>C</source>
         <translation>C</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="240"/>
+        <location filename="gui_ui.py" line="250"/>
         <source>Locales</source>
         <translation>위치</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="241"/>
+        <location filename="gui_ui.py" line="251"/>
         <source>64</source>
         <translation>64</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="242"/>
+        <location filename="gui_ui.py" line="252"/>
         <source>128</source>
         <translation>128</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="243"/>
+        <location filename="gui_ui.py" line="253"/>
         <source>256</source>
         <translation>256</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="244"/>
+        <location filename="gui_ui.py" line="254"/>
         <source>512</source>
         <translation>512</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="245"/>
+        <location filename="gui_ui.py" line="255"/>
         <source>1024</source>
         <translation>1024</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="246"/>
+        <location filename="gui_ui.py" line="256"/>
         <source>2048</source>
         <translation>2048</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="247"/>
+        <location filename="gui_ui.py" line="257"/>
         <source>4086</source>
         <translation>4086</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="248"/>
+        <location filename="gui_ui.py" line="258"/>
         <source>640x480</source>
         <translation>640x480</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="249"/>
+        <location filename="gui_ui.py" line="259"/>
         <source>800x600</source>
         <translation>800x600</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="250"/>
+        <location filename="gui_ui.py" line="260"/>
         <source>1024x768</source>
         <translation>1024x768</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="251"/>
+        <location filename="gui_ui.py" line="261"/>
         <source>SquashFS format</source>
         <translation>SquashFS 형식</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="252"/>
+        <location filename="gui_ui.py" line="262"/>
         <source>xz</source>
         <translation>xz</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="253"/>
+        <location filename="gui_ui.py" line="263"/>
         <source>gzip</source>
         <translation>gzip</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="254"/>
+        <location filename="gui_ui.py" line="264"/>
         <source>Settings</source>
         <translation>세팅</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="255"/>
+        <location filename="gui_ui.py" line="265"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;set on runtime!&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="285"/>
-        <source>About</source>
-        <translation>이 프로그램에 대해서</translation>
-    </message>
-    <message>
-        <location filename="gui_ui.py" line="231"/>
+        <location filename="gui_ui.py" line="241"/>
         <source> Extra Customization </source>
         <translation>커스터마이징 추가</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="232"/>
+        <location filename="gui_ui.py" line="242"/>
         <source>Browse FileSystem</source>
         <translation>파일시스템 탐색</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="233"/>
+        <location filename="gui_ui.py" line="243"/>
         <source>Browse ISO</source>
         <translation>ISO 탐색</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="234"/>
+        <location filename="gui_ui.py" line="244"/>
         <source>Extra</source>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="gui_ui.py" line="256"/>
+        <location filename="gui_ui.py" line="266"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -245,76 +240,108 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Thanks to all who helped making this project useful to this date!&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="gui_ui.py" line="295"/>
+        <source>Credits</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gui_ui.py" line="296"/>
+        <source>The GNU General Public License version 2 (GPLv2)
+
+Copyright (C) 2010-2013 Ivailo Monev
+Copyright (C) 2013-2015 Mubiin Kimura
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="gui_ui.py" line="314"/>
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>app</name>
     <message>
-        <location filename="gui.py" line="41"/>
+        <location filename="gui.py" line="42"/>
         <source>Information</source>
         <translation>안내</translation>
     </message>
     <message>
-        <location filename="gui.py" line="44"/>
+        <location filename="gui.py" line="45"/>
         <source>Warning</source>
         <translation>주의</translation>
     </message>
     <message>
-        <location filename="gui.py" line="47"/>
+        <location filename="gui.py" line="48"/>
         <source>Critical</source>
         <translation>치명적</translation>
     </message>
     <message>
-        <location filename="gui.py" line="60"/>
+        <location filename="gui.py" line="61"/>
         <source>An instance of Customizer is already running.</source>
         <translation>커스터마이저의 한 예가 이미 실행중입니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="67"/>
+        <location filename="gui.py" line="68"/>
         <source>You are attempting to run Customizer with Python 3.</source>
         <translation>당신은 파이썬 3으로 커스터마이저를 실행하려고합니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="145"/>
+        <location filename="gui.py" line="146"/>
         <source>The filesystem is not valid or corrupted. Clean is recommended.</source>
         <translation>파일시스템이 잘못되거나 손상되었습니다. 청소를 하는 것이 좋습니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="166"/>
+        <location filename="gui.py" line="169"/>
         <source>No supported terminal emulator detected.</source>
         <translation>지원되는 터미널 에뮬레이터가 감지 되지 않습니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="228"/>
+        <location filename="gui.py" line="232"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="gui.py" line="228"/>
+        <location filename="gui.py" line="232"/>
         <source>ISO Files (*.iso);;All Files (*)</source>
         <translation>ISO 파일 (*.iso);;모든 파일 (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="261"/>
+        <location filename="gui.py" line="269"/>
         <source>No supported text editor detected.</source>
         <translation>지원되는 텍스트 에디터가 감지 되지 않습니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="274"/>
+        <location filename="gui.py" line="282"/>
         <source>Deb Files (*.deb);;All Files (*)</source>
         <translation>Deb 파일 (*.deb);;모든 파일 (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="290"/>
+        <location filename="gui.py" line="300"/>
         <source>Shell Scripts (*.sh);;All Files (*)</source>
         <translation>쉘 스크립트 (*.sh);;모든 파일 (*)</translation>
     </message>
     <message>
-        <location filename="gui.py" line="374"/>
+        <location filename="gui.py" line="396"/>
         <source>No supported file manager detected.</source>
         <translation>지원되는 파일 탐색기가 감지 되지 않습니다.</translation>
     </message>
     <message>
-        <location filename="gui.py" line="320"/>
+        <location filename="gui.py" line="335"/>
         <source>Live user can not be empty.</source>
         <translation type="unfinished">라이브 유저는 비워 둘 수 없습니다 .</translation>
     </message>


### PR DESCRIPTION
As discussed in #109 all updates have been tested.
- Chunked hashing has been implemented, drastically dropping Customizer's memory usage.
- Apt will not automatically launch daemons when packages are installed in the chroot.
- Swapped out all instances of unicode(<something>)  with u'{}'.format(<something>) and now everything works fine in python3.
- We still print a message that you're running it under python3, but it's no longer a truly critical error, so the exit 0 was removed.
- Problem with Empty Dialogs in non-english locales has been resolved.

Some notes on changes I made to how terminals launch:

To resolve the problems I was having with the terminal, I added a last terminal to check for, x-terminal-emulator, which will invoke debian's alternatives system to select the terminal the user has expressed a preference for. 

Make sure your /etc/alternatives/x-terminal-emulator is linked to the terminal you'd like customizer to use. 

``` bash
update-alternatives --list x-terminal-emulator
```

will list known terminals, and

``` bash
update-alternatives --config x-terminal-emulator
```

will display a list for you to choose a new one you prefer better.
It's the last terminal in the list; so if it doesn't exist, you'll end up with the last one found.
So, for you people on Arch, it should still work without debian's alternatives system around. \o/

gnome-terminal seems to be having issues after it's split into a backend/frontend process and which method was used as elevation to root -- pkexec, gksudo, or sudo.
pkexec seems to work best on older releases like 14.04, but fails on 15.10 with Xmir :0.0 errors.
gksudo seems to work on 15.04 and 15.10, but xubuntu doesn't have the gksu package.
